### PR TITLE
Delete account feature

### DIFF
--- a/firebase/functions/index.js
+++ b/firebase/functions/index.js
@@ -328,7 +328,7 @@ async function onUserDelete(user) {
 
     // Delete help offers for all (ask-for-help, solved and deleted)
     const deletedPostOffersEntries = await getEntriesOfUser(db, 'offer-help', 'email', user.email, true);
-    deletedPostOffersEntries.docs.forEach((doc) => doc.ref.delete());
+    deletedPostOffersEntries.docs.forEach((doc) => doc.ref.update({ email: '', answer: '' }));
 
     // Delete notifications
     const notificationEntries = await getEntriesOfUser(db, 'notifications', 'd.uid', user.uid);

--- a/firebase/functions/index.js
+++ b/firebase/functions/index.js
@@ -318,28 +318,17 @@ async function onUserDelete(user) {
     const askForHelpEntries = await getEntriesOfUser(db, 'ask-for-help', 'd.uid', user.uid);
     askForHelpEntries.docs.forEach((doc) => deleteDocumentWithSubCollections(db, 'ask-for-help', doc.id));
 
-    // Delete help offers
-    const askForHelpOffersEntries = await getEntriesOfUser(db, 'offer-help', 'email', user.email, true);
-    askForHelpOffersEntries.docs.forEach((doc) => doc.ref.delete());
-
-
     // Delete solved posts
     const solvedPostEntries = await getEntriesOfUser(db, 'solved-posts', 'd.uid', user.uid);
     solvedPostEntries.docs.forEach((doc) => deleteDocumentWithSubCollections(db, 'solved-posts', doc.id));
-
-    // Delete help offers
-    const solvedPostOffersEntries = await getEntriesOfUser(db, 'offer-help', 'email', user.email, true);
-    solvedPostOffersEntries.docs.forEach((doc) => doc.ref.delete());
-
 
     // Delete delted post
     const deletedPostEntries = await getEntriesOfUser(db, 'deleted', 'd.uid', user.uid);
     deletedPostEntries.docs.forEach((doc) => deleteDocumentWithSubCollections(db, 'deleted', doc.id));
 
-    // Delete help offers
+    // Delete help offers for all (ask-for-help, solved and deleted)
     const deletedPostOffersEntries = await getEntriesOfUser(db, 'offer-help', 'email', user.email, true);
     deletedPostOffersEntries.docs.forEach((doc) => doc.ref.delete());
-
 
     // Delete notifications
     const notificationEntries = await getEntriesOfUser(db, 'notifications', 'd.uid', user.uid);
@@ -350,8 +339,14 @@ async function onUserDelete(user) {
     reportedPostsEntries.docs.forEach((doc) => doc.ref.update({ uid: 'ghost-user' }));
 
     // Anonymize ask-for-help reported-by
-    const askForHelpReportedByEntries = await db.collection('ask-for-help').where('d.uid', 'in', reportedPostsEntries.docs.map((doc) => doc.data().askForHelpId)).get();
-    askForHelpReportedByEntries.docs.forEach((doc) => {
+    const reportedEntryIds = reportedPostsEntries.docs.map((doc) => doc.data().askForHelpId);
+    const askForHelpPromise = await db.collection('ask-for-help').where('d.uid', 'in', reportedEntryIds).get();
+    const solvedPromise = await db.collection('solved-posts').where('d.uid', 'in', reportedEntryIds).get();
+    const deletedPromise = await db.collection('deleted').where('d.uid', 'in', reportedEntryIds).get();
+
+    const result = await Promise.all([askForHelpPromise, solvedPromise, deletedPromise]);
+    const reportedEntries = result.reduce((arr, elem) => arr.concat(elem.docs), []);
+    reportedEntries.forEach((doc) => {
       doc.ref.update({ d: { reportedBy: admin.firestore.FieldValue.arrayRemove(user.uid) } });
       if (!doc.data().d.reportedBy.includes('ghost-user')) {
         doc.ref.update({ d: { reportedBy: admin.firestore.FieldValue.arrayUnion('ghost-user') } });

--- a/firebase/functions/index.js
+++ b/firebase/functions/index.js
@@ -323,7 +323,7 @@ async function onUserDelete(user) {
     const solvedPostEntries = await getEntriesOfUser(db, 'solved-posts', 'd.uid', user.uid);
     promises.push(solvedPostEntries.docs.map((doc) => deleteDocumentWithSubCollections(db, 'solved-posts', doc.id)));
 
-    // Delete delted post
+    // Delete deleted posts
     const deletedPostEntries = await getEntriesOfUser(db, 'deleted', 'd.uid', user.uid);
     promises.push(deletedPostEntries.docs.map((doc) => deleteDocumentWithSubCollections(db, 'deleted', doc.id)));
 

--- a/firebase/functions/index.js
+++ b/firebase/functions/index.js
@@ -328,7 +328,7 @@ async function onUserDelete(user) {
 
     // Delete help offers for all (ask-for-help, solved and deleted)
     const helpOfferEntries = await getEntriesOfUser(db, 'offer-help', 'email', user.email, true);
-    deletedPostOffersEntries.docs.forEach((doc) => doc.ref.update({ email: '', answer: '' }));
+    helpOfferEntries.docs.forEach((doc) => doc.ref.update({ email: '', answer: '' }));
 
     // Delete notifications
     const notificationEntries = await getEntriesOfUser(db, 'notifications', 'd.uid', user.uid);

--- a/firebase/functions/index.js
+++ b/firebase/functions/index.js
@@ -340,12 +340,11 @@ async function onUserDelete(user) {
 
     // Anonymize reported-by
     const reportedEntryIds = reportedPostsEntries.docs.map((doc) => doc.data().askForHelpId);
-    const entryRefs = [];
-    for (let i = 0; i < reportedEntryIds.length; i += 1) {
-      entryRefs.push(db.collection('ask-for-help').doc(reportedEntryIds[i]));
-      entryRefs.push(db.collection('solved-posts').doc(reportedEntryIds[i]));
-      entryRefs.push(db.collection('deleted').doc(reportedEntryIds[i]));
-    }
+    const entryRefs = reportedEntryIds.map((id) => [
+      db.collection('ask-for-help').doc(id),
+      db.collection('solved-posts').doc(id),
+      db.collection('deleted').doc(id),
+    ]).reduce((arr, elem) => arr.concat(elem), []);
 
     const reportedEntries = await db.getAll(...entryRefs);
     reportedEntries.forEach((doc) => {

--- a/firebase/functions/index.js
+++ b/firebase/functions/index.js
@@ -327,7 +327,7 @@ async function onUserDelete(user) {
     deletedPostEntries.docs.forEach((doc) => deleteDocumentWithSubCollections(db, 'deleted', doc.id));
 
     // Delete help offers for all (ask-for-help, solved and deleted)
-    const deletedPostOffersEntries = await getEntriesOfUser(db, 'offer-help', 'email', user.email, true);
+    const helpOfferEntries = await getEntriesOfUser(db, 'offer-help', 'email', user.email, true);
     deletedPostOffersEntries.docs.forEach((doc) => doc.ref.update({ email: '', answer: '' }));
 
     // Delete notifications

--- a/firebase/functions/index.js
+++ b/firebase/functions/index.js
@@ -96,11 +96,11 @@ async function searchAndSendNotificationEmails() {
   const getEligibleHelpOffers = async (askForHelpSnapData) => {
     let queryResult = [];
     if (MAPS_ENABLED) {
-      const offersRef = new GeoCollectionReference(db.collection('offer-help'));
-      const query = offersRef.near({ center: askForHelpSnapData.coordinates, radius: 30 });
+      const notificationsRef = new GeoCollectionReference(db.collection('notifications'));
+      const query = notificationsRef.near({ center: askForHelpSnapData.coordinates, radius: 30 });
       queryResult = (await query.get()).docs.map((doc) => doc.data());
     } else {
-      const offersRef = db.collection('offer-help');
+      const notificationsRef = db.collection('notifications');
       if (!askForHelpSnapData || !askForHelpSnapData.d || !askForHelpSnapData.d.plz) {
         // eslint-disable-next-line no-console
         console.warn('Failed to find plz for ask-for-help ', askForHelpSnapData);
@@ -108,7 +108,7 @@ async function searchAndSendNotificationEmails() {
         const search = askForHelpSnapData.d.plz;
         const start = `${search.slice(0, -3)}000`;
         const end = `${search.slice(0, -3)}999`;
-        const results = await offersRef.orderBy('d.plz').startAt(start).endAt(end).get();
+        const results = await notificationsRef.orderBy('d.plz').startAt(start).endAt(end).get();
         const allPossibleOffers = results.docs
           .map((doc) => ({ id: doc.id, ...doc.data().d }))
           .filter(({ plz }) => plz.length === search.length);
@@ -321,7 +321,7 @@ exports.askForHelpCreate = functions
 exports.regionSubscribeCreate = functions
   .region(REGION_EUROPE_WEST_1)
   .firestore
-  .document('/offer-help/{helperId}')
+  .document('/notifications/{helperId}')
   .onCreate(onSubscribeToBeNotifiedCreate);
 
 exports.reportedPostsCreate = functions

--- a/firebase/functions/utils.js
+++ b/firebase/functions/utils.js
@@ -73,15 +73,11 @@ async function deleteDocumentWithSubCollections(db, collectionName, documentId) 
 }
 
 async function getEntriesOfUser(db, collection, key, uid, useCollectionGroup = false) {
-  let userEntries;
   if (!useCollectionGroup) {
-    userEntries = await db.collection(collection).where(key, '==', uid).get();
-  } else {
-    userEntries = await db.collectionGroup(collection).where(key, '==', uid).get();
-  }
-  return userEntries;
+    return db.collection(collection).where(key, '==', uid).get();
+  } 
+  return db.collectionGroup(collection).where(key, '==', uid).get();
 }
-
 module.exports = {
   userIdsMatch,
   migrateResponses,

--- a/firebase/functions/utils.js
+++ b/firebase/functions/utils.js
@@ -75,7 +75,7 @@ async function deleteDocumentWithSubCollections(db, collectionName, documentId) 
 async function getEntriesOfUser(db, collection, key, uid, useCollectionGroup = false) {
   if (!useCollectionGroup) {
     return db.collection(collection).where(key, '==', uid).get();
-  } 
+  }
   return db.collectionGroup(collection).where(key, '==', uid).get();
 }
 module.exports = {

--- a/firebase/functions/utils.js
+++ b/firebase/functions/utils.js
@@ -72,8 +72,19 @@ async function deleteDocumentWithSubCollections(db, collectionName, documentId) 
   return deleteCollection(db, collectionPath, batchSize);
 }
 
+async function getEntriesOfUser(db, collection, key, uid, useCollectionGroup = false) {
+  let userEntries;
+  if (!useCollectionGroup) {
+    userEntries = await db.collection(collection).where(key, '==', uid).get();
+  } else {
+    userEntries = await db.collectionGroup(collection).where(key, '==', uid).get();
+  }
+  return userEntries;
+}
+
 module.exports = {
   userIdsMatch,
   migrateResponses,
   deleteDocumentWithSubCollections,
+  getEntriesOfUser,
 };

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -313,7 +313,7 @@
       "password": "Passwort",
       "confirmDeletion": "Löschen bestätigen",
       "repeatePassword": "Passwort erneut eingeben",
-      "deleteFinally": "Account unwiederuflich löschen",
+      "deleteFinally": "Account unwideruflich löschen",
       "abort": "Abbrechen",
       "wrongPassword": "Dein angegebenes Passwort ist leider inkorrekt"
     },

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -76,7 +76,7 @@
         "postBreak": "Drucke <1>diesen Aushang</1>."
       }
     },
-    "completeOfferHelp": {
+    "completeNotification": {
       "youAreHero": "Du bist eine Held*in!",
       "mailVerified": "Deine E-Mail-Adresse wurde verifiziert! Du wirst nun von uns per E-Mail benachrichtigt werden, wenn jemand in",
       "needsHelp": "Hilfe benötigt",

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -302,6 +302,12 @@
     "statusIndicator": {
       "toHome": "ZUR STARTSEITE"
     },
+    "responses": {
+      "answerDeleted": "Diese Antwort wurde gelöscht.",
+      "answer": "Antworten",
+      "answerFrom": "Antwort von",
+      "answersLoading": "Antworten werden geladen"
+    },
     "deleteAccountButton": {
       "deleteAccount": "Account löschen",
       "password": "Passwort",

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -302,6 +302,9 @@
     "statusIndicator": {
       "toHome": "ZUR STARTSEITE"
     },
+    "deleteAccountButton": {
+      "wrongPassword": "Dein angegebenes Passwort ist leider inkorrekt"
+    },
     "desktopMenu": {
       "myOverview": "Meine Übersicht",
       "requestHelp": "HILFE ANFRAGEN",

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -303,6 +303,12 @@
       "toHome": "ZUR STARTSEITE"
     },
     "deleteAccountButton": {
+      "deleteAccount": "Account löschen",
+      "password": "Passwort",
+      "confirmDeletion": "Löschen bestätigen",
+      "repeatePassword": "Passwort erneut eingeben",
+      "deleteFinally": "Account unwiederuflich löschen",
+      "abort": "Abbrechen",
       "wrongPassword": "Dein angegebenes Passwort ist leider inkorrekt"
     },
     "desktopMenu": {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -30,7 +30,7 @@ import PrivacyPolicy from './views/PrivacyPolicy';
 import Sidebar from './components/Sidebar';
 import DesktopLowerNavigation from './components/DesktopMenu';
 import VerifyEmail from './views/VerifyEmail';
-import CompleteOfferHelp from './views/CompleteOfferHelp';
+import CompleteNotification from './views/CompleteNotification';
 import NotifyMe from './views/NotifyMe';
 import useScrollToTop from './components/ScrollToTop';
 import ShareButtons from './components/ShareButtons';
@@ -285,9 +285,9 @@ export default function App() {
             <NotifyMe />
           </Page>
         </Route>
-        <Route path="/complete-offer-help">
+        <Route path="/complete-notification">
           <Page>
-            <CompleteOfferHelp />
+            <CompleteNotification />
           </Page>
         </Route>
         <Route path="/handle-email-action">

--- a/src/components/Responses.jsx
+++ b/src/components/Responses.jsx
@@ -1,24 +1,36 @@
 import React, { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import formatDistance from 'date-fns/formatDistance';
 import { de } from 'date-fns/locale';
 import loadResponses from '../services/loadResponses';
 
 const Response = ({ response }) => {
   const date = formatDistance(new Date(response.timestamp), Date.now(), { locale: de, addSuffix: true });
+  const { t } = useTranslation();
+
+  if (!response.email && !response.answer) {
+    return (
+      <li className="px-4 py-2 ml-12 mr-1 block relative font-open-sans response">
+        <p className="my-2 italic text-gray-800 whitespace-pre-line">{t('components.responses.answerDeleted')}</p>
+        <p className="text-gray-500 text-right text-xs">{date}</p>
+      </li>
+    );
+  }
 
   return (
-    <li className="px-4 py-2 my-1 block relative ml-12 font-open-sans response">
+    <li className="px-4 py-2 ml-12 mr-1 block relative font-open-sans response">
       <div className="flex flex-row flex-wrap items-center mt-2 text-sm">
         <span className="flex-grow text-gray-800 break-all">
-          {'Antwort von '}
+          {t('components.responses.answerFrom')}
+          {' '}
           <a href={`mailto:${response.email}`} className="font-bold">{response.email}</a>
         </span>
         <a href={`mailto:${response.email}`} className="flex-grow ml-2 text-right text-secondary uppercase">
-          <span className="font-bold">Antworten</span>
+          <span className="font-bold">{t('components.responses.answer')}</span>
           <span className="ml-1 text-xl leading-0">&raquo;</span>
         </a>
       </div>
-      <p className="mt-2 mb-2 text-xl text-gray-800 whitespace-pre-line">{response.answer}</p>
+      <p className="my-2 text-xl text-gray-800 whitespace-pre-line">{response.answer}</p>
       <p className="text-gray-500 text-right text-xs">{date}</p>
     </li>
   );
@@ -26,6 +38,7 @@ const Response = ({ response }) => {
 
 export default function Responses({ id, collectionName }) {
   const [responses, setResponses] = useState(undefined);
+  const { t } = useTranslation();
 
   useEffect(() => {
     loadResponses(id, collectionName).then(setResponses);
@@ -34,8 +47,12 @@ export default function Responses({ id, collectionName }) {
   return (
     <div>
       {responses === undefined
-        ? <p className="my-3 ml-6 font-open-sans text-gray-800">Antworten werden geladen &hellip;</p>
-        : (
+        ? (
+          <p className="my-3 ml-6 font-open-sans text-gray-800">
+            {t('components.responses.answersLoading')}
+            &hellip;
+          </p>
+        ) : (
           <ul className="mt-8 mb-12">
             {responses.map((response) => <Response key={response.id} response={response} />)}
           </ul>

--- a/src/views/CompleteNotification.jsx
+++ b/src/views/CompleteNotification.jsx
@@ -13,7 +13,7 @@ import Loader from '../components/loader/Loader';
 import buildSha1Hash from '../util/buildHash';
 import useQuery from '../util/useQuery';
 
-export default function CompleteOfferHelp() {
+export default function CompleteNotification() {
   const { t } = useTranslation();
   const queryParams = useQuery();
   const [user] = useAuthState(fb.auth);
@@ -22,9 +22,9 @@ export default function CompleteOfferHelp() {
   const [location, setLocation] = useState('');
   const [success, setSuccess] = useState(false);
 
-  const createOfferHelp = async (loc, placeId, email) => {
+  const createNotification = async (loc, placeId, email) => {
     const geofirestore = new GeoFirestore(fb.store);
-    const offerHelpCollection = geofirestore.collection('/offer-help');
+    const notificationCollection = geofirestore.collection('notifications');
 
     let lat = 0;
     let lng = 0;
@@ -44,7 +44,7 @@ export default function CompleteOfferHelp() {
     }
 
     // Create will work but subsequent updates will fail. This is to prevent duplicates
-    await offerHelpCollection.doc(await buildSha1Hash(`${email}_${plz}`)).set({
+    await notificationCollection.doc(await buildSha1Hash(`${email}_${plz}`)).set({
       email,
       location: loc,
       plz,
@@ -57,12 +57,12 @@ export default function CompleteOfferHelp() {
   };
 
   useEffect(() => {
-    async function completeOfferHelp() {
+    async function completeNotification() {
       const { location: loc, placeId } = queryParams;
 
       setLocation(loc);
       try {
-        await createOfferHelp(loc, placeId, user.email);
+        await createNotification(loc, placeId, user.email);
         setSuccess(true);
       } catch (err) {
         Sentry.captureException(err);
@@ -71,7 +71,7 @@ export default function CompleteOfferHelp() {
     }
 
     if (user) {
-      completeOfferHelp();
+      completeNotification();
     }
   }, [queryParams, user]); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -82,13 +82,13 @@ export default function CompleteOfferHelp() {
   if (!success) {
     return (
       <>
-        <h1 className="text-2xl font-exo2 mt-10 mb-6">{t('views.completeOfferHelp.anErrorOccured')}</h1>
+        <h1 className="text-2xl font-exo2 mt-10 mb-6">{t('views.completeNotification.anErrorOccured')}</h1>
         <p>
-          {t('views.completeOfferHelp.error')}
+          {t('views.completeNotification.error')}
         </p>
         <div className="flex justify-center flex-col items-center mb-8">
           <img className="h-48 w-48 my-10" src={require('../assets/error.svg')} alt="" />
-          <Link className="btn-green mt-10" to="/notify-me">{t('views.completeOfferHelp.tryAgain')}</Link>
+          <Link className="btn-green mt-10" to="/notify-me">{t('views.completeNotification.tryAgain')}</Link>
         </div>
       </>
     );
@@ -96,17 +96,17 @@ export default function CompleteOfferHelp() {
 
   return (
     <>
-      <h1 className="text-2xl font-exo2 mt-10 mb-6">{t('views.completeOfferHelp.youAreHero')}</h1>
+      <h1 className="text-2xl font-exo2 mt-10 mb-6">{t('views.completeNotification.youAreHero')}</h1>
       <p>
-        {t('views.completeOfferHelp.mailVerified')}
+        {t('views.completeNotification.mailVerified')}
         {' '}
         <span className="text-secondary">{location}</span>
         {' '}
-        {t('views.completeOfferHelp.needsHelp')}
+        {t('views.completeNotification.needsHelp')}
       </p>
       <div className="flex justify-center flex-col items-center mb-8">
         <img className="h-48 w-48 my-10" src={require('../assets/success.svg')} alt="" />
-        <Link className="btn-green mt-10" to="/dashboard">{t('views.completeOfferHelp.toYourOverview')}</Link>
+        <Link className="btn-green mt-10" to="/dashboard">{t('views.completeNotification.toYourOverview')}</Link>
       </div>
     </>
   );

--- a/src/views/Dashboard.jsx
+++ b/src/views/Dashboard.jsx
@@ -212,6 +212,7 @@ function DeleteAccountButton({ user, className }) {
     <Popup
       modal
       trigger={<button type="button" className={className}>{t('components.deleteAccountButton.deleteAccount')}</button>}
+      onClose={() => setError('')}
       // we cannot set this with classes because the popup library has inline style, which would overwrite the width and padding again
       contentStyle={
         {

--- a/src/views/Dashboard.jsx
+++ b/src/views/Dashboard.jsx
@@ -175,7 +175,7 @@ function Dashboard(props) {
         )
         : offers.map((offer) => <Notification location={offer.location} id={offer.id} key={offer.id} />)}
 
-      <div className="mt-3">
+      <div className="mt-12">
         <DeleteAccountButton className="rounded text-white p-3 btn-main bg-primary hover:opacity-75 float-right" user={user} />
       </div>
     </div>
@@ -207,7 +207,7 @@ function DeleteAccountButton({ user, className }) {
   return (
     <Popup
       modal
-      trigger={<button type="button" className={className}>Account löschen</button>}
+      trigger={<button type="button" className={className}>{t('components.deleteAccountButton.deleteAccount')}</button>}
       lockScroll
       // we cannot set this with classes because the popup library has inline style, which would overwrite the width and padding again
       contentStyle={
@@ -223,11 +223,11 @@ function DeleteAccountButton({ user, className }) {
       {(close) => (
         <div className="flex flex-col p-8 bg-kaki">
           <div className="font-teaser mb-6">
-            Löschen bestätigen
+            {t('components.deleteAccountButton.confirmDeletion')}
           </div>
           <form onSubmit={deleteAccount}>
             <label className="block text-gray-700 text-sm font-bold mb-1 text font-open-sans" htmlFor="password_repeat">
-              Passwort
+              {t('components.deleteAccountButton.password')}
             </label>
             <input
               className="appearance-none border rounded w-full py-2 px-3 text-gray-700 mb-3 leading-tight focus:outline-none input-focus"
@@ -235,13 +235,13 @@ function DeleteAccountButton({ user, className }) {
               name="password"
               type="password"
               autoComplete="password"
-              placeholder="Passwort erneut eingeben"
+              placeholder={t('components.deleteAccountButton.repeatePassword')}
               required="required"
             />
             {error && <div data-cy="error-label" className="text-red-500">{error}</div>}
-            <button type="submit" className="mt-4 rounded text-white p-3 btn-main bg-primary hover:opacity-75 float-right w-full">Account unwiederuflich löschen</button>
+            <button type="submit" className="mt-4 rounded text-white p-3 btn-main bg-primary hover:opacity-75 float-right w-full">{t('components.deleteAccountButton.deleteFinally')}</button>
           </form>
-          <button type="button" className="mt-2 btn-green-secondary" onClick={close}>Abbrechen</button>
+          <button type="button" className="mt-2 btn-green-secondary" onClick={close}>{t('components.deleteAccountButton.abort')}</button>
         </div>
       )}
     </Popup>

--- a/src/views/Dashboard.jsx
+++ b/src/views/Dashboard.jsx
@@ -8,6 +8,7 @@ import {
   Tabs, Tab, TabPanel, TabList,
 } from 'react-web-tabs';
 import * as firebase from 'firebase/app';
+import * as Sentry from '@sentry/browser';
 import fb from '../firebase';
 import Entry from '../components/entry/Entry';
 import useQuery from '../util/useQuery';
@@ -199,7 +200,10 @@ function DeleteAccountButton({ user, className }) {
     } catch (err) {
       switch (err.code) {
         case 'auth/wrong-password': setError(t('components.deleteAccountButton.wrongPassword')); break;
-        default: setError(err.message);
+        default: {
+          setError(err.message);
+          Sentry.captureException(err);
+        }
       }
     }
   };

--- a/src/views/Dashboard.jsx
+++ b/src/views/Dashboard.jsx
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next';
 import {
   Tabs, Tab, TabPanel, TabList,
 } from 'react-web-tabs';
+import * as firebase from 'firebase/app';
 import fb from '../firebase';
 import Entry from '../components/entry/Entry';
 import useQuery from '../util/useQuery';
@@ -72,6 +73,20 @@ function Dashboard(props) {
   const solvedPosts = (solvedPostsDocs || [])
     .map((doc) => ({ ...doc.d, id: doc.id }))
     .sort((a, b) => b.timestamp - a.timestamp);
+
+
+  const deleteAccount = async () => {
+    // TODO: Show reassurance dialog and ask for PW
+    const pw = window.prompt('Reenter PW');
+    try {
+      const credentials = await firebase.auth.EmailAuthProvider.credential(user.email, pw);
+      await user.reauthenticateWithCredential(credentials);
+
+      user.delete();
+    } catch (err) {
+      console.log("Error", err);
+    }
+  };
 
   if (isLoadingRequestsForHelp || isLoadingOffers || isLoadingSolvedPosts) {
     // Commented out until there is a consistent way of showing placeholders on the site
@@ -172,6 +187,9 @@ function Dashboard(props) {
         )
         : offers.map((offer) => <Notification location={offer.location} id={offer.id} key={offer.id} />)}
 
+      <div className="mt-3">
+        <button type="button" className="rounded text-white p-3 btn-main bg-primary hover:opacity-75 float-right" onClick={deleteAccount}>Delete Account</button>
+      </div>
     </div>
   );
 }

--- a/src/views/Dashboard.jsx
+++ b/src/views/Dashboard.jsx
@@ -212,15 +212,14 @@ function DeleteAccountButton({ user, className }) {
     <Popup
       modal
       trigger={<button type="button" className={className}>{t('components.deleteAccountButton.deleteAccount')}</button>}
-      lockScroll
       // we cannot set this with classes because the popup library has inline style, which would overwrite the width and padding again
       contentStyle={
         {
           padding: '0',
           width: 'auto',
-          borderWidth: '0px',
           maxWidth: '90%',
-          minWidth: '50%',
+          minWidth: '30%',
+          borderWidth: '0px',
         }
       }
     >

--- a/src/views/Dashboard.jsx
+++ b/src/views/Dashboard.jsx
@@ -208,7 +208,6 @@ function DeleteAccountButton({ user, className }) {
     <Popup
       modal
       trigger={<button type="button" className={className}>Account löschen</button>}
-      onClose={(e) => e.preventDefault()}
       lockScroll
       // we cannot set this with classes because the popup library has inline style, which would overwrite the width and padding again
       contentStyle={

--- a/src/views/Dashboard.jsx
+++ b/src/views/Dashboard.jsx
@@ -12,7 +12,7 @@ import Entry from '../components/entry/Entry';
 import useQuery from '../util/useQuery';
 
 const askForHelpCollection = fb.store.collection('ask-for-help');
-const offerHelpCollection = fb.store.collection('offer-help');
+const notificationCollection = fb.store.collection('notifications');
 const solvedPostsCollection = fb.store.collection('solved-posts');
 
 function Notification(props) {
@@ -21,7 +21,7 @@ function Notification(props) {
     location,
   } = props;
   const onDeleteClick = () => {
-    offerHelpCollection.doc(props.id).delete();
+    notificationCollection.doc(props.id).delete();
   };
 
   return (
@@ -61,7 +61,7 @@ function Dashboard(props) {
     .sort((a, b) => b.timestamp - a.timestamp);
 
   const [offersDocs, isLoadingOffers] = useCollectionDataOnce(
-    offerHelpCollection.where('d.uid', '==', user.uid),
+    notificationCollection.where('d.uid', '==', user.uid),
     { idField: 'id' },
   );
   const offers = (offersDocs || []).map((doc) => ({ ...doc.d, id: doc.id }));

--- a/src/views/NotifyMe.jsx
+++ b/src/views/NotifyMe.jsx
@@ -20,7 +20,7 @@ export default function NotifyMe() {
 
     try {
       await fb.auth.sendSignInLinkToEmail(email, {
-        url: `${baseUrl}/#/complete-offer-help?location=${location}&placeId=${placeId}`,
+        url: `${baseUrl}/#/complete-notification?location=${location}&placeId=${placeId}`,
         handleCodeInApp: true,
       });
       window.localStorage.setItem('emailForSignIn', email);


### PR DESCRIPTION
**What changes does this PR introduce**

* Adds a button to the Dashboard that allows users to delete their account
* Upon clicking, the user has to reenter the PW to confirm the account deletion
* Once the account is deleted in Firebase, a cloud function is triggered, deleting all data associated with the user
* For reported posts, we replace any user did by "ghost-user" in order to not loose this information completely

**TODOs before merge**
- [x] Rename firestore rules on prod /offer-help to /notifications
- [x] Run migration on prod
- [ ] Delete old collection on prod

**Others details**
This feature requires us to rename the collection /offer-help. I renamed it to /notifiactions as this is what is stored in the collection.

Closes #62 