### PR TITLE
Fix issue where token and user object are out of sync

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -41,6 +41,7 @@ import arrowUpIcon from './assets/arrows_up.svg';
 import FilteredListFrame from './views/FilteredListFrame';
 import Footer from './components/Footer';
 import HandleEmailAction from './views/HandleEmailAction';
+import isEmailVerified from './util/emailVerified';
 
 function DesktopTopNavigation({ isAuthLoading, user, signOut }) {
   const { t } = useTranslation();

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -41,7 +41,6 @@ import arrowUpIcon from './assets/arrows_up.svg';
 import FilteredListFrame from './views/FilteredListFrame';
 import Footer from './components/Footer';
 import HandleEmailAction from './views/HandleEmailAction';
-import isEmailVerified from './util/emailVerified';
 
 function DesktopTopNavigation({ isAuthLoading, user, signOut }) {
   const { t } = useTranslation();

--- a/src/util/emailVerified.js
+++ b/src/util/emailVerified.js
@@ -1,0 +1,49 @@
+import { useEffect, useState } from 'react';
+import { useAuthState } from 'react-firebase-hooks/auth';
+
+export default async function isEmailVerified(user) {
+  if (!user) {
+    return false;
+  }
+
+  const token = await user.getIdTokenResult();
+  const emailVerifiedStateFromToken = token.claims.email_verified;
+
+  if (emailVerifiedStateFromToken !== user.emailVerified) {
+    console.log('Tokens out of sync. Refreshing');
+    const newToken = await user.getIdTokenResult(true);
+    if (newToken.claims.email_verified !== user.emailVerified) {
+      throw new Error('The state of the idToken and user.emailVerified is out of sync even after a refresh');
+    }
+
+    return newToken.claims.emailVerified;
+  }
+
+  return emailVerifiedStateFromToken;
+}
+
+export function useEmailVerified(auth) {
+  const [user, isAuthLoading] = useAuthState(auth);
+
+  const [state, setState] = useState({
+    loading: true,
+    emailVerified: false,
+  });
+
+  useEffect(() => {
+    async function run() {
+      setState({
+        loading: true,
+        emailVerified: false,
+      });
+      const isVerified = await isEmailVerified(user);
+      setState({
+        loading: false,
+        emailVerified: isVerified,
+      });
+    }
+    run();
+  }, [user, isAuthLoading]);
+
+  return [state.emailVerified, state.loading];
+}

--- a/src/views/AskForHelp.jsx
+++ b/src/views/AskForHelp.jsx
@@ -7,11 +7,14 @@ import fb from '../firebase';
 import LocationInput from '../components/LocationInput';
 import { isMapsApiEnabled } from '../featureFlags';
 import { getGeodataForPlace, getGeodataForString, getLatLng } from '../services/GeoService';
+import { useEmailVerified } from '../util/emailVerified';
 
 export default function AskForHelp() {
   const { t } = useTranslation();
 
   const [user, isAuthLoading] = useAuthState(fb.auth);
+  const [emailVerified, emailVerifiedLoading] = useEmailVerified(fb.auth);
+
   const [request, setRequest] = useState('');
   const [location, setLocation] = useState('');
   const [placeId, setPlaceId] = useState(undefined);
@@ -72,7 +75,7 @@ export default function AskForHelp() {
     return <Redirect to="/signin/ask-for-help" />;
   }
 
-  if (!user.emailVerified) {
+  if (!emailVerifiedLoading && !emailVerified) {
     return <Redirect to="/verify-email" />;
   }
 

--- a/src/views/Signin.jsx
+++ b/src/views/Signin.jsx
@@ -14,6 +14,7 @@ import MailInput from '../components/MailInput';
 import fb from '../firebase';
 
 import { baseUrl } from '../appConfig';
+import { useEmailVerified } from '../util/emailVerified';
 
 export default function Signin() {
   const [email, setEmail] = React.useState('');
@@ -23,13 +24,23 @@ export default function Signin() {
   const location = useLocation();
   const { t } = useTranslation();
   const [user] = useAuthState(firebase.auth());
+  const [emailVerified, emailVerifiedLoading] = useEmailVerified(firebase.auth());
   const signInWithEmailAndPassword = (mail, pw) => firebase.auth().signInWithEmailAndPassword(mail, pw);
 
   const { returnUrl } = useParams();
 
   if (user) {
-    if (returnUrl) return <Redirect to={`/${decodeURIComponent(returnUrl)}`} />;
-    return user.emailVerified ? <Redirect to="/ask-for-help" /> : <Redirect to="/verify-email" />;
+    if (returnUrl) {
+      return <Redirect to={`/${decodeURIComponent(returnUrl)}`} />;
+    }
+
+    if (!emailVerifiedLoading && !emailVerified) {
+      return <Redirect to="/verify-email" />;
+    }
+
+    if (!emailVerifiedLoading && emailVerified) {
+      return <Redirect to="/ask-for-help" />;
+    }
   }
 
   const reasonForSignin = location && location.state && location.state.reason_for_registration

--- a/src/views/Signup.jsx
+++ b/src/views/Signup.jsx
@@ -11,12 +11,14 @@ import { useAuthState } from 'react-firebase-hooks/auth';
 import { useTranslation } from 'react-i18next';
 import MailInput from '../components/MailInput';
 import { baseUrl } from '../appConfig';
+import { useEmailVerified } from '../util/emailVerified';
 
 export default () => {
   const [email, setEmail] = React.useState('');
   const [password, setPassword] = React.useState('');
   const [error, setError] = React.useState('');
   const [user] = useAuthState(firebase.auth());
+  const [emailVerified, emailVerifiedLoading] = useEmailVerified(firebase.auth());
   const location = useLocation();
   const passwordInput = useRef();
   const passwordRepeatInput = useRef();
@@ -26,8 +28,17 @@ export default () => {
   const createUserWithEmailAndPassword = (mail, pw) => firebase.auth().createUserWithEmailAndPassword(mail, pw);
 
   if (user) {
-    if (returnUrl) return <Redirect to={`/${decodeURIComponent(returnUrl)}`} />;
-    return user.emailVerified ? <Redirect to="/ask-for-help" /> : <Redirect to="/verify-email" />;
+    if (returnUrl) {
+      return <Redirect to={`/${decodeURIComponent(returnUrl)}`} />;
+    }
+
+    if (!emailVerifiedLoading && !emailVerified) {
+      return <Redirect to="/verify-email" />;
+    }
+
+    if (!emailVerifiedLoading && emailVerified) {
+      return <Redirect to="/ask-for-help" />;
+    }
   }
 
   const reasonForSignup = location && location.state && location.state.reason_for_registration

--- a/src/views/VerifyEmail.jsx
+++ b/src/views/VerifyEmail.jsx
@@ -5,11 +5,13 @@ import { useTranslation } from 'react-i18next';
 import * as firebase from 'firebase/app';
 import 'firebase/auth';
 import { baseUrl } from '../appConfig';
+import { useEmailVerified } from '../util/emailVerified';
 
 
 export default () => {
   const [sendVerificationSuccess, setSendVerificationSuccess] = React.useState(false);
   const [user, isAuthLoading] = useAuthState(firebase.auth());
+  const [emailVerified, emailVerifiedLoading] = useEmailVerified(firebase.auth());
 
   const { t } = useTranslation();
 
@@ -17,7 +19,8 @@ export default () => {
     return <Redirect to="/signup" />;
   }
 
-  if (user && user.emailVerified) {
+  if (user && !emailVerifiedLoading && emailVerified) {
+    console.log('Email Verified. Redirecting to ask for help');
     return <Redirect to="/ask-for-help" />;
   }
 

--- a/src/views/VerifyEmail.jsx
+++ b/src/views/VerifyEmail.jsx
@@ -20,7 +20,6 @@ export default () => {
   }
 
   if (user && !emailVerifiedLoading && emailVerified) {
-    console.log('Email Verified. Redirecting to ask for help');
     return <Redirect to="/ask-for-help" />;
   }
 


### PR DESCRIPTION
**The problem**

The user object exposed by firebase has a property called `emailVerified`. This property updates based on the information which is saved in the user database of firebase. It gets updated whenever we load the user information, i.e. via `useAuthState(firebase.auth())`. 
This means that when a user verifies himself and we redirect to another page or a browser refresh happens, that this property is `true`.

Firebase internally uses a JWT for authenticating against its different APIs. This token contains a claim `emailVerified`. This claim is only updated when a user performs a `signIn` or when `user.refreshIdToken(true /* force refresh */)` is called in the code.

It can now happen that a user verifies his email in a different browser than the one he is using to interact with our platform (i.e. verifying on mobile, interacting on desktop).
In this case the user object will be set to `user.emailVerified = true`, whereas the claim will be set to `claims.emailVerified = false`. It can now happen that we allow the user to interact with APIs by showing him some UI based on his `user.emailVerified = true` status, but the subsequent requests to the firebase datasbase will fail with permissions errors because the claims are not properly updated yet. 

**Possible solutions**
 1. Find those edge-cases as described above in our code and call `user.refreshIdToken(true)` in those cases → in my opinion very complex and error prone
2. Use a top-level hook which refreshes the token on each page load → Performs many requests, but relatively safe in terms of consistency
3. Use a hook to check the state and consistency of `emailVerified`.

I've implemented option 3 here because I believe this might be the most robust way to solve this problem. @mauriceackel might also have another concept at hand which we could compare this to. 

The interesting part of this hook is a check where I verify that the claim inside the JWT and the emailVerified property of the user object are in sync. Only if they differ in their state will I perform a forced update, i.e. network request, in order to update the token to match the actual state.

I have yet to fully test this through, but as of now this seems to work in staging.

This code still fails in production because `user.refreshIdToken(true)` is not allowed with our current api key permissions. We (@kenodressel) must add the _Token Service API_ permission to the browser key. I've verified that this makes the difference by adding and removing (and now re-adding) this permission to the staging key. 
Because of this missing permission, currently also the "Bestätigung überprüfen" button does not work in production. (@jagaSto @kenodressel has this ever worked in prod?)