### PR TITLE
Logging out user on verify email

### DIFF
--- a/src/views/HandleEmailAction.jsx
+++ b/src/views/HandleEmailAction.jsx
@@ -153,7 +153,8 @@ function VerifyEmailView({ continueUrl, actionCode }) {
 
   const verifyEmail = async () => {
     try {
-      if (user) {
+      const tokenInfo = await firebase.auth().checkActionCode(actionCode);
+      if (user && user.email !== tokenInfo.data.email) {
         await firebase.auth().signOut();
       }
       await firebase.auth().applyActionCode(actionCode);

--- a/src/views/HandleEmailAction.jsx
+++ b/src/views/HandleEmailAction.jsx
@@ -153,6 +153,9 @@ function VerifyEmailView({ continueUrl, actionCode }) {
 
   const verifyEmail = async () => {
     try {
+      if (user) {
+        await firebase.auth().signOut();
+      }
       await firebase.auth().applyActionCode(actionCode);
       setLoading(false);
     } catch (err) {


### PR DESCRIPTION
**What changes does this PR introduce**

When a user opens a verify email link in a browser it is currently logged in, the user gets logged out first. The issue was, that a user could be logged in with a different user than the one it tries to verify the email for. This would cause confusion after email verification.